### PR TITLE
add violation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ Adds the given hook.  Available hooks:
 
     This hook can only be set once.
 
+- violations
+
+    ```perl
+    $test_critic->add_hook(violations => sub ($test_critic, @violations) {
+      ...
+    });
+    ```
+
+    Each time violations are returned from ["critique" in Perl::Critic](https://metacpan.org/pod/Perl::Critic#critique), they are
+    passed into this hook as a list.  The order and grouping of violations
+    may change in the future.
+
 # CAVEATS
 
 [Test::Perl::Critic](https://metacpan.org/pod/Test::Perl::Critic) has been around longer, and probably does at least some things smarter.


### PR DESCRIPTION
This adds a violation hook which is called whenever new violations are found.  Current implementation effectively groups violations by file, but we don't specify an ordering or grouping.